### PR TITLE
adds NE.Tree_Hugger option to control attacks on tree death

### DIFF
--- a/Natural_Evolution_Enemies/config.lua
+++ b/Natural_Evolution_Enemies/config.lua
@@ -79,6 +79,8 @@ NE.Scorched_Earth = true
 NE.Burning_Buildings = true
 -- When an entity is destroyed, it will catch fire.
 
+NE.Tree_Hugger = true
+-- When tree hugger is enabled, you may be attacked for cutting down trees
 
 NE.SafeRail = false -- Kinda obsolete... so just leave it alone
 -- If true, rail will have 100% immunity to damage.

--- a/Natural_Evolution_Enemies/control.lua
+++ b/Natural_Evolution_Enemies/control.lua
@@ -257,7 +257,7 @@ end
 function On_Remove(event)
 		
  	--------- Did you really just kill that tree...
-	if (event.entity.type == "tree") and tree_names[event.entity.name] then
+	if NE.Tree_Hugger != false and (event.entity.type == "tree") and tree_names[event.entity.name] then
 	
 		writeDebug("Tree Mined")
 		local surface = event.entity.surface
@@ -369,7 +369,7 @@ function On_Death(event)
 
 	
  	--------- Did you really just kill that tree...
-	if (event.entity.type == "tree") and tree_names[event.entity.name] then
+	if NE.Tree_Hugger != false and (event.entity.type == "tree") and tree_names[event.entity.name] then
 		writeDebug("Tree Killed")
 		local surface = event.entity.surface
 		local force = event.entity.force


### PR DESCRIPTION
Obviously, it's your call whether you choose to merge this option.

Alternatively, could base this behavior on whether `NE.Set_Difficulty` is `1` or `2`, if you want this behavior to be more of a surprise/challenge.

... I have to admit it took me quite a while to realize this is _why_ I was getting attacked so much. :evergreen_tree::deciduous_tree: 

Also, I'm not sure why killing by tank avoided triggering attacks, based on what I can see, that might be a bug?
